### PR TITLE
Replace deprecated get/setpos methods

### DIFF
--- a/home_gui/init.lua
+++ b/home_gui/init.lua
@@ -53,7 +53,7 @@ end
 home_gui.go_home = function(player)
 	local pos = homepos[player:get_player_name()]
 	if pos~=nil then
-		player:setpos(pos)
+		player:set_pos(pos)
 		player:set_eye_offset({x=0,y=0,z=0}, {x=0,y=0,z=0})
 		default.player_set_animation(player, "stand" , 30)
 	end
@@ -104,7 +104,7 @@ end)
 -- register_on_player_receive_fields
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if fields.home_gui_set then
-		home_gui.set_home(player, player:getpos())
+		home_gui.set_home(player, player:get_pos())
 	end
 	if fields.home_gui_go then
 		home_gui.go_home(player)


### PR DESCRIPTION
Replaces deprecated `getpos` & `setpos` methods with `get_pos` & `set_pos`.